### PR TITLE
Make file/.aliases more POSIX-compatible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ name: Super-lint project
 
 on:
   push: {}
+  pull_request: {}
 
 jobs:
   lint:

--- a/files/.aliases
+++ b/files/.aliases
@@ -89,7 +89,8 @@ _EOF_
 # remove remains from super-linter runs to prevent appending
 remove-super-linter-log () {
 	if [[ -f "$1/super-linter.log" ]]; then
-		read -rp "Remove old super-lint.log [Y|n|append]: " ANSWER
+		echo -n "Remove old super-lint.log [Y|n|append]: "
+		read -r ANSWER
 		case "$ANSWER" in
 			n|no|N|No|NO|nein|Nein|NEIN)
 				echo "exiting now"


### PR DESCRIPTION
The -p flag of read is not a part of the POSIX standard and interpreted
differently in bash and zsh.  Running echo prior to read is preferred.

Tested in bash and zsh.